### PR TITLE
chore: Update GitHub Actions (python-build-standalone) artifact actions v3 to v4 [CLOUD-344]

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -31,7 +31,7 @@ jobs:
           cargo build --release
 
       - name: Upload pythonbuild Executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pythonbuild
           path: target/release/pythonbuild
@@ -151,7 +151,7 @@ jobs:
           python-version: '3.11'
 
       - name: Download pythonbuild
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pythonbuild
           path: build
@@ -192,7 +192,7 @@ jobs:
           build/pythonbuild validate-distribution --macos-sdks-path macosx-sdks ${EXTRA_ARGS} dist/*.tar.zst
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.build.py }}-${{ matrix.build.target_triple }}
           path: dist/*

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -1,8 +1,14 @@
+# on:
+#   push:
+#   pull_request:
+#   schedule:
+#     - cron: '13 11 * * *'
+
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: '13 11 * * *'
+    branches:
+      - cloud-344/python-build-standalone/v3-to-v4
+    
 jobs:
   pythonbuild:
     runs-on: 'macos-11'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,8 +1,12 @@
+# on:
+#   push:
+#   pull_request:
+#   schedule:
+#     - cron: '13 11 * * *'
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: '13 11 * * *'
+    branches:
+      - cloud-344/python-build-standalone/v3-to-v4
 jobs:
   pythonbuild:
     runs-on: ubuntu-22.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
           cargo build --release
 
       - name: Upload pythonbuild Executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pythonbuild
           path: target/release/pythonbuild
@@ -106,7 +106,7 @@ jobs:
           zstd -v -T0 -6 --rm build/image-*.tar
 
       - name: Upload Docker Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: images
           path: build/image-*
@@ -775,13 +775,13 @@ jobs:
           python-version: '3.11'
 
       - name: Download pythonbuild
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pythonbuild
           path: build
 
       - name: Download images
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images
           path: build
@@ -819,7 +819,7 @@ jobs:
           build/pythonbuild validate-distribution ${EXTRA_ARGS} dist/*.tar.zst
 
       - name: Upload Distribution
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.build.py }}-${{ matrix.build.target_triple }}
           path: dist/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
           cargo build --release
 
       - name: Upload executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pythonbuild
           path: target/release/pythonbuild.exe
@@ -69,7 +69,7 @@ jobs:
           python-version: '3.11'
 
       - name: Download pythonbuild Executable
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pythonbuild
 
@@ -91,7 +91,7 @@ jobs:
           .\pythonbuild.exe validate-distribution --run $Dists
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.py }}-${{ matrix.vcvars }}
           path: dist/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,8 +1,13 @@
+# on:
+#   push:
+#   pull_request:
+#   schedule:
+#     - cron: '13 11 * * *'
+
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: '13 11 * * *'
+    branches:
+      - cloud-344/python-build-standalone/v3-to-v4
 jobs:
   pythonbuild:
     runs-on: 'windows-2019'


### PR DESCRIPTION
what

Updated GitHub Actions workflows to replace actions/upload-artifact@v3 and actions/download-artifact@v3 with v4.
Ensured compatibility with existing CI/CD processes.

https://butterflynetwork.atlassian.net/browse/CLOUD-344

why

GitHub has announced the deprecation of v3 for these actions, with full removal by January 30, 2025.
Temporary brownouts are already causing failures in workflows using the deprecated version.
Upgrading to v4 ensures uninterrupted CI/CD pipeline execution.

Reference

GitHub Deprecation Notice